### PR TITLE
Enable JPMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     def conscrypt = "2.5.2"
     def annotations = "24.0.1"
 
-    implementation "org.jetbrains:annotations:${annotations}"
+    compileOnly("org.jetbrains:annotations:$annotations")
 
     compileOnly("io.javalin:javalin:$javalin")
     implementation(platform("io.javalin:javalin-parent:$javalin")) //Javalin BOM

--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,14 @@ plugins {
 
 group = 'io.javalin.community.ssl'
 //Must be formatted following the RegEx: /version\s*=\s*'\S+'/g
-version = '5.5.0'
+version = '5.5.1-SNAPSHOT'
 
 jacoco {
     toolVersion = '0.8.8'
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
         url "https://maven.reposilite.com/snapshots" //Javalin Snapshots
@@ -41,11 +42,14 @@ configurations {
 }
 
 dependencies {
-    def javalin = "5.5.0"
+    def javalin = "5.5.1-SNAPSHOT"
     def junit = '5.9.1'
-    def sslContextKickstart = '7.5.0'
+    def sslContextKickstart = '8.0.0'
     def okhttp = "4.11.0"
     def conscrypt = "2.5.2"
+    def annotations = "24.0.1"
+
+    implementation "org.jetbrains:annotations:${annotations}"
 
     compileOnly("io.javalin:javalin:$javalin")
     implementation(platform("io.javalin:javalin-parent:$javalin")) //Javalin BOM

--- a/src/intTest/java/io/javalin/community/ssl/PemLoadingTests.java
+++ b/src/intTest/java/io/javalin/community/ssl/PemLoadingTests.java
@@ -1,16 +1,16 @@
 package io.javalin.community.ssl;
 
 import io.javalin.community.ssl.certs.Server;
-import nl.altindag.ssl.exception.CertificateParseException;
 import nl.altindag.ssl.exception.GenericIOException;
-import nl.altindag.ssl.exception.PrivateKeyParseException;
+import nl.altindag.ssl.pem.exception.CertificateParseException;
+import nl.altindag.ssl.pem.exception.PrivateKeyParseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("integration")
 public class PemLoadingTests extends IntegrationTestClass {

--- a/src/intTest/java/io/javalin/community/ssl/certs/CertificateAuthorityTests.java
+++ b/src/intTest/java/io/javalin/community/ssl/certs/CertificateAuthorityTests.java
@@ -4,7 +4,7 @@ import io.javalin.Javalin;
 import io.javalin.community.ssl.IntegrationTestClass;
 import io.javalin.community.ssl.SSLPlugin;
 import nl.altindag.ssl.SSLFactory;
-import nl.altindag.ssl.util.PemUtils;
+import nl.altindag.ssl.pem.util.PemUtils;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/src/main/java/io/javalin/community/ssl/util/SSLUtils.java
+++ b/src/main/java/io/javalin/community/ssl/util/SSLUtils.java
@@ -4,8 +4,8 @@ import io.javalin.community.ssl.SSLConfig;
 import io.javalin.community.ssl.SSLConfigException;
 import io.javalin.community.ssl.TrustConfig;
 import nl.altindag.ssl.SSLFactory;
-import nl.altindag.ssl.util.JettySslUtils;
-import nl.altindag.ssl.util.PemUtils;
+import nl.altindag.ssl.jetty.util.JettySslUtils;
+import nl.altindag.ssl.pem.util.PemUtils;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import javax.net.ssl.X509ExtendedKeyManager;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+module io.javalin.community.ssl {
+  exports io.javalin.community.ssl;
+  exports io.javalin.community.ssl.util;
+
+  requires io.javalin;
+  requires org.eclipse.jetty.server;
+  requires org.eclipse.jetty.alpn.server;
+  requires org.eclipse.jetty.http2.server;
+  requires nl.altindag.ssl;
+  requires nl.altindag.ssl.jetty;
+  requires nl.altindag.ssl.pem;
+  requires org.conscrypt;
+  requires lombok;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -10,5 +10,6 @@ module io.javalin.community.ssl {
   requires nl.altindag.ssl.jetty;
   requires nl.altindag.ssl.pem;
   requires org.conscrypt;
-  requires lombok;
+
+  requires static lombok;
 }


### PR DESCRIPTION
Modularisation:
1. Added **module-info.java**.
2. Upgraded **sslcontext-kickstart** to the modular **8.0.0** version.
3. Fixed imports to reflect package changes in **sslcontext-kickstart**.

Steps 2 and 3 perhaps belong in the [Bump sslContextKickstart from 7.5.0 to 8.0.0](https://github.com/javalin/javalin-ssl/pull/83) PR?

Other changes I had to make:
1. Version bumped to 5.5.1-SNAPSHOT.
2. **mavenLocal()** added to repositories, so I could refer to the 5.5.1-SNAPSHOT version of Javalin I built.
3. **jetbrains.annotations** added as a **compileOnly** dependency.

I ran into problems regarding Lombok, if I clean and build, the build fails with a bunch of module related errors both during **compileJava** and **delombok**, but the next time I build it succeeds, don't know what that's all about (never used Lombok before).